### PR TITLE
Building documentation via sphinx

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: check
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -31,3 +31,9 @@ jobs:
     - name: Typecheck
       run: |
         mypy
+    - name: Documentation
+      run: |
+        pip install sphinx
+        cd docs
+        mkdir _target && mkdir _static
+        sphinx-build . _target/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 `itu.algs4` is a Python 3 port of the Java code in [Algorithms, 4th Edition](https://algs4.cs.princeton.edu/home/).
 
 [![Build Status](https://github.com/itu-algorithms/itu.algs4/workflows/check/badge.svg)](https://github.com/itu-algorithms/itu.algs4/actions)
+[![Documentation Status](https://readthedocs.org/projects/itualgs4/badge/?version=latest)](https://itualgs4.readthedocs.io/en/latest/?badge=latest)
 
 ## Target audience
 
@@ -136,6 +137,8 @@ from itu.algs4.graphs.edge_weighted_digraph import EdgeWeightedDigraph
 
 
 ## Documentation
+
+The documentation can be found [here](https://itualgs4.readthedocs.io/en/latest/).
 
 You can use Python's built-in `help` function on any package, sub-package, public class, or function to get a description of what it contains or does. This documentation should also show up in your IDE of choice.
 For example `help(itu.algs4)` yields the following:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,53 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'itu.algs4'
+copyright = '2020, ITU Algorithms Group'
+author = 'ITU Algorithms Group'
+master_doc = 'index'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ "sphinx.ext.autodoc"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,27 @@
+.. itu.algs4 documentation master file, created by
+   sphinx-quickstart on Mon Jul  6 13:50:43 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to itu.algs4's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   source/itu.algs4.fundamentals.rst
+   source/itu.algs4.graphs.rst
+   source/itu.algs4.searching.rst
+   source/itu.algs4.sorting.rst
+   source/itu.algs4.stdlib.rst
+   source/itu.algs4.strings.rst
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+pygame
+typing_extensions
+color

--- a/docs/source/itu.algs4.errors.rst
+++ b/docs/source/itu.algs4.errors.rst
@@ -1,0 +1,22 @@
+itu.algs4.errors package
+========================
+
+Submodules
+----------
+
+itu.algs4.errors.errors module
+------------------------------
+
+.. automodule:: itu.algs4.errors.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.fundamentals.rst
+++ b/docs/source/itu.algs4.fundamentals.rst
@@ -1,0 +1,94 @@
+itu.algs4.fundamentals package
+==============================
+
+Submodules
+----------
+
+itu.algs4.fundamentals.bag module
+---------------------------------
+
+.. automodule:: itu.algs4.fundamentals.bag
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.binary\_search module
+--------------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.binary_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.evaluate module
+--------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.evaluate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.java\_helper module
+------------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.java_helper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.queue module
+-----------------------------------
+
+.. automodule:: itu.algs4.fundamentals.queue
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.stack module
+-----------------------------------
+
+.. automodule:: itu.algs4.fundamentals.stack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.three\_sum module
+----------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.three_sum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.three\_sum\_fast module
+----------------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.three_sum_fast
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.two\_sum\_fast module
+--------------------------------------------
+
+.. automodule:: itu.algs4.fundamentals.two_sum_fast
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.fundamentals.uf module
+--------------------------------
+
+.. automodule:: itu.algs4.fundamentals.uf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.fundamentals
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.graphs.rst
+++ b/docs/source/itu.algs4.graphs.rst
@@ -1,0 +1,286 @@
+itu.algs4.graphs package
+========================
+
+Submodules
+----------
+
+itu.algs4.graphs.Arbitrage module
+---------------------------------
+
+.. automodule:: itu.algs4.graphs.Arbitrage
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.CPM module
+---------------------------
+
+.. automodule:: itu.algs4.graphs.CPM
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.acyclic\_lp module
+-----------------------------------
+
+.. automodule:: itu.algs4.graphs.acyclic_lp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.acyclic\_sp module
+-----------------------------------
+
+.. automodule:: itu.algs4.graphs.acyclic_sp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.bellman\_ford\_sp module
+-----------------------------------------
+
+.. automodule:: itu.algs4.graphs.bellman_ford_sp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.bipartite module
+---------------------------------
+
+.. automodule:: itu.algs4.graphs.bipartite
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.breadth\_first\_paths module
+---------------------------------------------
+
+.. automodule:: itu.algs4.graphs.breadth_first_paths
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.cc module
+--------------------------
+
+.. automodule:: itu.algs4.graphs.cc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.cycle module
+-----------------------------
+
+.. automodule:: itu.algs4.graphs.cycle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.degrees\_of\_separation module
+-----------------------------------------------
+
+.. automodule:: itu.algs4.graphs.degrees_of_separation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.depth\_first\_order module
+-------------------------------------------
+
+.. automodule:: itu.algs4.graphs.depth_first_order
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.depth\_first\_paths module
+-------------------------------------------
+
+.. automodule:: itu.algs4.graphs.depth_first_paths
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.depth\_first\_search module
+--------------------------------------------
+
+.. automodule:: itu.algs4.graphs.depth_first_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.digraph module
+-------------------------------
+
+.. automodule:: itu.algs4.graphs.digraph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.dijkstra\_all\_pairs\_sp module
+------------------------------------------------
+
+.. automodule:: itu.algs4.graphs.dijkstra_all_pairs_sp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.dijkstra\_sp module
+------------------------------------
+
+.. automodule:: itu.algs4.graphs.dijkstra_sp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.dijkstra\_undirected\_sp module
+------------------------------------------------
+
+.. automodule:: itu.algs4.graphs.dijkstra_undirected_sp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.directed\_cycle module
+---------------------------------------
+
+.. automodule:: itu.algs4.graphs.directed_cycle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.directed\_dfs module
+-------------------------------------
+
+.. automodule:: itu.algs4.graphs.directed_dfs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.directed\_edge module
+--------------------------------------
+
+.. automodule:: itu.algs4.graphs.directed_edge
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.edge module
+----------------------------
+
+.. automodule:: itu.algs4.graphs.edge
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.edge\_weighted\_digraph module
+-----------------------------------------------
+
+.. automodule:: itu.algs4.graphs.edge_weighted_digraph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.edge\_weighted\_directed\_cycle module
+-------------------------------------------------------
+
+.. automodule:: itu.algs4.graphs.edge_weighted_directed_cycle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.edge\_weighted\_directed\_cycle\_anton module
+--------------------------------------------------------------
+
+.. automodule:: itu.algs4.graphs.edge_weighted_directed_cycle_anton
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.edge\_weighted\_graph module
+---------------------------------------------
+
+.. automodule:: itu.algs4.graphs.edge_weighted_graph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.graph module
+-----------------------------
+
+.. automodule:: itu.algs4.graphs.graph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.kosaraju\_sharir\_scc module
+---------------------------------------------
+
+.. automodule:: itu.algs4.graphs.kosaraju_sharir_scc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.kruskal\_mst module
+------------------------------------
+
+.. automodule:: itu.algs4.graphs.kruskal_mst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.lazy\_prim\_mst module
+---------------------------------------
+
+.. automodule:: itu.algs4.graphs.lazy_prim_mst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.prim\_mst module
+---------------------------------
+
+.. automodule:: itu.algs4.graphs.prim_mst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.symbol\_digraph module
+---------------------------------------
+
+.. automodule:: itu.algs4.graphs.symbol_digraph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.symbol\_graph module
+-------------------------------------
+
+.. automodule:: itu.algs4.graphs.symbol_graph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.topological module
+-----------------------------------
+
+.. automodule:: itu.algs4.graphs.topological
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.graphs.transitive\_closure module
+-------------------------------------------
+
+.. automodule:: itu.algs4.graphs.transitive_closure
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.graphs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.rst
+++ b/docs/source/itu.algs4.rst
@@ -1,0 +1,24 @@
+itu.algs4 package
+=================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   itu.algs4.errors
+   itu.algs4.fundamentals
+   itu.algs4.graphs
+   itu.algs4.searching
+   itu.algs4.sorting
+   itu.algs4.stdlib
+   itu.algs4.strings
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.searching.rst
+++ b/docs/source/itu.algs4.searching.rst
@@ -1,0 +1,118 @@
+itu.algs4.searching package
+===========================
+
+Submodules
+----------
+
+itu.algs4.searching.binary\_search\_st module
+---------------------------------------------
+
+.. automodule:: itu.algs4.searching.binary_search_st
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.bst module
+------------------------------
+
+.. automodule:: itu.algs4.searching.bst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.file\_index module
+--------------------------------------
+
+.. automodule:: itu.algs4.searching.file_index
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.frequency\_counter module
+---------------------------------------------
+
+.. automodule:: itu.algs4.searching.frequency_counter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.linear\_probing\_hst module
+-----------------------------------------------
+
+.. automodule:: itu.algs4.searching.linear_probing_hst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.lookup\_csv module
+--------------------------------------
+
+.. automodule:: itu.algs4.searching.lookup_csv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.lookup\_index module
+----------------------------------------
+
+.. automodule:: itu.algs4.searching.lookup_index
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.red\_black\_bst module
+------------------------------------------
+
+.. automodule:: itu.algs4.searching.red_black_bst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.seperate\_chaining\_hst module
+--------------------------------------------------
+
+.. automodule:: itu.algs4.searching.seperate_chaining_hst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.sequential\_search\_st module
+-------------------------------------------------
+
+.. automodule:: itu.algs4.searching.sequential_search_st
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.set module
+------------------------------
+
+.. automodule:: itu.algs4.searching.set
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.sparse\_vector module
+-----------------------------------------
+
+.. automodule:: itu.algs4.searching.sparse_vector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.searching.st module
+-----------------------------
+
+.. automodule:: itu.algs4.searching.st
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.searching
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.sorting.rst
+++ b/docs/source/itu.algs4.sorting.rst
@@ -1,0 +1,102 @@
+itu.algs4.sorting package
+=========================
+
+Submodules
+----------
+
+itu.algs4.sorting.heap module
+-----------------------------
+
+.. automodule:: itu.algs4.sorting.heap
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.index\_min\_pq module
+---------------------------------------
+
+.. automodule:: itu.algs4.sorting.index_min_pq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.insertion\_sort module
+----------------------------------------
+
+.. automodule:: itu.algs4.sorting.insertion_sort
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.max\_pq module
+--------------------------------
+
+.. automodule:: itu.algs4.sorting.max_pq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.merge module
+------------------------------
+
+.. automodule:: itu.algs4.sorting.merge
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.merge\_bu module
+----------------------------------
+
+.. automodule:: itu.algs4.sorting.merge_bu
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.min\_pq module
+--------------------------------
+
+.. automodule:: itu.algs4.sorting.min_pq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.quick3way module
+----------------------------------
+
+.. automodule:: itu.algs4.sorting.quick3way
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.quicksort module
+----------------------------------
+
+.. automodule:: itu.algs4.sorting.quicksort
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.selection module
+----------------------------------
+
+.. automodule:: itu.algs4.sorting.selection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.sorting.shellsort module
+----------------------------------
+
+.. automodule:: itu.algs4.sorting.shellsort
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.sorting
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.stdlib.rst
+++ b/docs/source/itu.algs4.stdlib.rst
@@ -1,0 +1,118 @@
+itu.algs4.stdlib package
+========================
+
+Submodules
+----------
+
+itu.algs4.stdlib.binary\_out module
+-----------------------------------
+
+.. automodule:: itu.algs4.stdlib.binary_out
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.binary\_stdin module
+-------------------------------------
+
+.. automodule:: itu.algs4.stdlib.binary_stdin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.binary\_stdout module
+--------------------------------------
+
+.. automodule:: itu.algs4.stdlib.binary_stdout
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.color module
+-----------------------------
+
+.. automodule:: itu.algs4.stdlib.color
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.instream module
+--------------------------------
+
+.. automodule:: itu.algs4.stdlib.instream
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.outstream module
+---------------------------------
+
+.. automodule:: itu.algs4.stdlib.outstream
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.picture module
+-------------------------------
+
+.. automodule:: itu.algs4.stdlib.picture
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stdarray module
+--------------------------------
+
+.. automodule:: itu.algs4.stdlib.stdarray
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stdaudio module
+--------------------------------
+
+.. automodule:: itu.algs4.stdlib.stdaudio
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stddraw module
+-------------------------------
+
+.. automodule:: itu.algs4.stdlib.stddraw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stdio module
+-----------------------------
+
+.. automodule:: itu.algs4.stdlib.stdio
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stdrandom module
+---------------------------------
+
+.. automodule:: itu.algs4.stdlib.stdrandom
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.stdlib.stdstats module
+--------------------------------
+
+.. automodule:: itu.algs4.stdlib.stdstats
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.stdlib
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/itu.algs4.strings.rst
+++ b/docs/source/itu.algs4.strings.rst
@@ -1,0 +1,102 @@
+itu.algs4.strings package
+=========================
+
+Submodules
+----------
+
+itu.algs4.strings.boyer\_moore module
+-------------------------------------
+
+.. automodule:: itu.algs4.strings.boyer_moore
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.huffman\_compression module
+---------------------------------------------
+
+.. automodule:: itu.algs4.strings.huffman_compression
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.kmp module
+----------------------------
+
+.. automodule:: itu.algs4.strings.kmp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.lsd module
+----------------------------
+
+.. automodule:: itu.algs4.strings.lsd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.lzw module
+----------------------------
+
+.. automodule:: itu.algs4.strings.lzw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.msd module
+----------------------------
+
+.. automodule:: itu.algs4.strings.msd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.nfa module
+----------------------------
+
+.. automodule:: itu.algs4.strings.nfa
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.quick3string module
+-------------------------------------
+
+.. automodule:: itu.algs4.strings.quick3string
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.rabin\_karp module
+------------------------------------
+
+.. automodule:: itu.algs4.strings.rabin_karp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.trie\_st module
+---------------------------------
+
+.. automodule:: itu.algs4.strings.trie_st
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+itu.algs4.strings.tst module
+----------------------------
+
+.. automodule:: itu.algs4.strings.tst
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: itu.algs4.strings
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This PR adds support to build the documentation via sphinx. The goal is to share the documentation as can be seen on https://itualgs4.readthedocs.io/en/sphinx-build/. 